### PR TITLE
Initial support for matching gene aliases, ids, etc

### DIFF
--- a/frontend/src/components/SwaggerDocs.tsx
+++ b/frontend/src/components/SwaggerDocs.tsx
@@ -5,6 +5,6 @@ import React, { Component } from 'react'
 
 export class SwaggerDocs extends Component<{}, {}> {
     render() {
-        return <SwaggerUI url='http://dev.varlex.org/openapi.json' docExpansion='list' />
+        return <SwaggerUI url='http://localhost:5000/openapi.json' docExpansion='list' />
     }
 }

--- a/frontend/src/components/TokenTable.tsx
+++ b/frontend/src/components/TokenTable.tsx
@@ -25,6 +25,7 @@ export class TokenTable extends Component<{}, State> {
                         <Table.Row>
                             <Table.HeaderCell>Term</Table.HeaderCell>
                             <Table.HeaderCell>Token Type</Table.HeaderCell>
+                            <Table.HeaderCell>Match Type</Table.HeaderCell>
                         </Table.Row>
                     </Table.Header>
                     {this.tableContents()}
@@ -60,6 +61,7 @@ export class TokenTable extends Component<{}, State> {
                 <Table.Row key={index}>
                     <Table.Cell>{token.token}</Table.Cell>
                     <Table.Cell>{token.tokenType}</Table.Cell>
+                    <Table.Cell>{token.matchType}</Table.Cell>
                 </Table.Row>
             );
             return <Table.Body>{rows}</Table.Body>

--- a/frontend/src/services/VarlexApi.ts
+++ b/frontend/src/services/VarlexApi.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { TokenResponse, ClassificationResponse } from "../types/VarlexTypes";
 
 const varlexApi = axios.create({
-  baseURL: "http://dev.varlex.org/",
+  baseURL: "http://localhost:5000/",
   headers: { Accept: "application/json" }
 });
 

--- a/frontend/src/types/VarlexTypes.ts
+++ b/frontend/src/types/VarlexTypes.ts
@@ -6,6 +6,7 @@ export interface TokenResponse {
 export interface Token {
   token: string;
   tokenType: string;
+  matchType: string;
 }
 
 export interface ClassificationResponse {

--- a/varlexapp/models/__init__.py
+++ b/varlexapp/models/__init__.py
@@ -4,3 +4,4 @@ from .classification import Classification
 from .confidence_rating import ConfidenceRating
 from .classification_response import ClassificationResponse
 from .classification_type import ClassificationType
+from .token_match_type import TokenMatchType

--- a/varlexapp/models/token.py
+++ b/varlexapp/models/token.py
@@ -1,4 +1,7 @@
+from .token_match_type import TokenMatchType
+
 class Token:
-    def __init__(self, token, token_type):
+    def __init__(self, token, token_type, match_type = TokenMatchType.UNSPECIFIED):
         self.token = token
         self.token_type = token_type
+        self.match_type = match_type

--- a/varlexapp/models/token_match_type.py
+++ b/varlexapp/models/token_match_type.py
@@ -1,0 +1,13 @@
+from enum import Enum, unique
+
+@unique
+class TokenMatchType(Enum):
+    ID = 1
+    SYMBOL = 2
+    ALIAS = 3
+    PREVIOUS = 4
+    UNSPECIFIED = 5
+
+
+    def __str__(self):
+        self.name

--- a/varlexapp/schemas/token_schema.py
+++ b/varlexapp/schemas/token_schema.py
@@ -1,5 +1,8 @@
 from marshmallow import Schema, fields
+from ..models import TokenMatchType
+from .apispec_enum_field import ApispecEnumField
 
 class TokenSchema(Schema):
     token = fields.Str()
     tokenType = fields.Str(attribute='token_type')
+    matchType = ApispecEnumField(TokenMatchType, attribute='match_type')

--- a/varlexapp/tokenizers/gene_pair.py
+++ b/varlexapp/tokenizers/gene_pair.py
@@ -1,15 +1,17 @@
 from .tokenizer import Tokenizer
+from .gene_symbol import GeneSymbol
 from ..models import Token
 
 class GenePair(Tokenizer):
     def __init__(self, gene_cache):
         self.__gene_cache = gene_cache
+        self.__gene_matcher = GeneSymbol(gene_cache)
 
     def match(self, input_string):
         potential_genes = input_string.split('-')
         if (len(potential_genes) == 2 and
-                potential_genes[0].upper() in self.__gene_cache and
-                potential_genes[1].upper() in self.__gene_cache):
+                self.__gene_matcher.match(potential_genes[0].upper()) and
+                self.__gene_matcher.match(potential_genes[1].upper())):
             return Token(input_string, 'GenePair')
         else:
             return None

--- a/varlexapp/tokenizers/gene_symbol.py
+++ b/varlexapp/tokenizers/gene_symbol.py
@@ -1,12 +1,19 @@
 from .tokenizer import Tokenizer
-from ..models import Token
+from ..models import Token, TokenMatchType
 
 class GeneSymbol(Tokenizer):
     def __init__(self, gene_cache):
-        self.__gene_cache = gene_cache
+        self.gene_cache = gene_cache
 
     def match(self, input_string):
-        if input_string.upper() in self.__gene_cache:
-            return Token(input_string, 'GeneSymbol')
+        uppercase_input = input_string.upper()
+        if uppercase_input in self.gene_cache.gene_symbols:
+            return Token(input_string, 'GeneSymbol', TokenMatchType.SYMBOL)
+        elif uppercase_input in self.gene_cache.gene_ids:
+            return Token(self.gene_cache.gene_ids[uppercase_input], 'GeneSymbol', TokenMatchType.ID)
+        elif uppercase_input in self.gene_cache.gene_aliases:
+            return Token(self.gene_cache.gene_aliases[uppercase_input], 'GeneSymbol', TokenMatchType.ALIAS)
+        elif uppercase_input in self.gene_cache.previous_identifiers:
+            return Token(self.gene_cache.previous_identifiers[uppercase_input], 'GeneSymbol', TokenMatchType.PREVIOUS)
         else:
             return None


### PR DESCRIPTION
This adds the idea of a "match type" to tokens (name, alias, id, etc) with various types of gene matches as the first test. 

This also allows the gene tokenizer to match on previous symbols, aliases, ids, etc, but we will likely want to discuss the specifics of the implementation. 