### PR TITLE
test harness for yaml fixtures

### DIFF
--- a/tests/fixtures/tokenizers.yml
+++ b/tests/fixtures/tokenizers.yml
@@ -1,0 +1,12 @@
+fusion:
+  should_match:
+    - token: Fusion
+    - token: fusions
+    - token: FUSION
+    - token: fuSions
+  should_not_match:
+    - token: afusion
+    - token: fused
+    - token: fusio
+
+

--- a/tests/tokenizers/test_fusion.py
+++ b/tests/tokenizers/test_fusion.py
@@ -1,31 +1,12 @@
-import unittest
-
 from varlexapp.tokenizers import Fusion
+from .tokenizer_test import TokenizerTest
 
-class TestFusionTokenizer(unittest.TestCase):
-    def setUp(self):
-        self.tokenizer = Fusion()
-        self.should_match = [
-            'Fusion',
-            'fusions',
-            'FUSION',
-            'fuSIons'
-        ]
+class TestFusionTokenizer(TokenizerTest):
+    def tokenizer_instance(self):
+        return Fusion()
 
-        self.should_not_match = [
-            'afusion',
-            'fused'
-        ]
+    def token_type(self):
+        return 'Fusion'
 
-    def test_matches(self):
-        for x in self.should_match:
-            res = self.tokenizer.match(x)
-            self.assertIsNotNone(res)
-            self.assertEqual('Fusion', res.token_type)
-
-        for x in self.should_not_match:
-            res = self.tokenizer.match(x)
-            self.assertIsNone(res)
-
-
-
+    def fixture_name(self):
+        return 'fusion'

--- a/tests/tokenizers/tokenizer_test.py
+++ b/tests/tokenizers/tokenizer_test.py
@@ -1,0 +1,33 @@
+import unittest
+import yaml
+
+class TokenizerTest(unittest.TestCase):
+
+    def setUp(self):
+        with open('tests/fixtures/tokenizers.yml') as stream:
+            self.all_fixtures = yaml.safe_load(stream)
+        self.fixtures = self.all_fixtures.get(
+                self.fixture_name(),
+                {'should_match': [], 'should_not_match': []}
+        )
+        self.tokenizer = self.tokenizer_instance()
+
+    def tokenizer_instance(self):
+        pass
+
+    def token_type(self):
+        pass
+
+    def fixture_name(self):
+        pass
+
+    def test_matches(self):
+        for x in self.fixtures['should_match']:
+            res = self.tokenizer.match(x['token'])
+            self.assertIsNotNone(res)
+            self.assertEqual(self.token_type(), res.token_type)
+
+    def test_not_matches(self):
+        for x in self.fixtures['should_not_match']:
+            res = self.tokenizer.match(x['token'])
+            self.assertIsNone(res)


### PR DESCRIPTION
This sets up a test harness so that we can supply as many test cases for the various tokenizers as we'd like via a yaml file. (Note that this does not actually include any additional tests, merely the scaffolding). 

Classifiers will use the same approach. Closes #4