### PR TITLE
Use CURIE notation for gene ids

### DIFF
--- a/varlexapp/tokenizers/caches/gene_symbol_cache.py
+++ b/varlexapp/tokenizers/caches/gene_symbol_cache.py
@@ -20,10 +20,13 @@ class GeneSymbolCache:
                 self.gene_symbols.add(symbol)
 
                 if row['entrez_id']:
-                    self.gene_ids[row['entrez_id'].upper()] = symbol
+                    curie_string = f"ncbigene:{row['entrez_id']}".upper()
+                    self.gene_ids[curie_string] = symbol
                 if row['ensembl_gene_id']:
-                    self.gene_ids[row['ensembl_gene_id'].upper()] = symbol
+                    curie_string = f"ensembl:{row['ensembl_gene_id']}".upper()
+                    self.gene_ids[curie_string] = symbol
                 if row['hgnc_id']:
+                    #already in curie format
                     self.gene_ids[row['hgnc_id'].upper()] = symbol
 
                 for x in self.__process_field(row['name']):

--- a/varlexapp/tokenizers/tokenize.py
+++ b/varlexapp/tokenizers/tokenize.py
@@ -54,6 +54,7 @@ class Tokenize:
         tokens = list()
 
         for term in terms:
+            if not term: continue
             matched = False
             for tokenizer in self.tokenizers:
                 res = tokenizer.match(term)


### PR DESCRIPTION
For gene identifiers (hgnc, entrez, ensembl, etc), use a curie style notation to differentiate which id type to look up.

Along with last week's PR, this closes #2 