### PR TITLE
Inject config from .env files at build time

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_DOMAIN=http://dev.varlex.org/

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_DOMAIN=http://localhost:5000/

--- a/frontend/src/components/SwaggerDocs.tsx
+++ b/frontend/src/components/SwaggerDocs.tsx
@@ -1,10 +1,12 @@
 import SwaggerUI from 'swagger-ui-react'
 import "swagger-ui-react/swagger-ui.css"
 import React, { Component } from 'react'
+import { varlexApiDomain } from "../services/Config";
 
 
 export class SwaggerDocs extends Component<{}, {}> {
     render() {
-        return <SwaggerUI url='http://localhost:5000/openapi.json' docExpansion='list' />
+        let url: string = `${varlexApiDomain()}openapi.json`
+        return <SwaggerUI url={url} docExpansion='list' />
     }
 }

--- a/frontend/src/services/Config.ts
+++ b/frontend/src/services/Config.ts
@@ -1,0 +1,3 @@
+export function varlexApiDomain(): string {
+  return process.env.REACT_APP_API_DOMAIN || "/";
+}

--- a/frontend/src/services/VarlexApi.ts
+++ b/frontend/src/services/VarlexApi.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import { TokenResponse, ClassificationResponse } from "../types/VarlexTypes";
+import { varlexApiDomain } from "../services/Config";
 
 const varlexApi = axios.create({
-  baseURL: "http://localhost:5000/",
+  baseURL: varlexApiDomain(),
   headers: { Accept: "application/json" }
 });
 


### PR DESCRIPTION
For now this lets us not have to toggle back and forth between domains
in dev vs prod, and will come in handy later as the application grows as
well.