### PR TITLE
Initial harness for classification testing

### DIFF
--- a/tests/classifiers/classifier_base.py
+++ b/tests/classifiers/classifier_base.py
@@ -1,0 +1,35 @@
+import unittest
+import yaml
+
+from varlexapp.tokenizers import Tokenize
+
+class ClassifierBase(object):
+
+    def setUp(self):
+        with open('tests/fixtures/classifiers.yml') as stream:
+            self.all_fixtures = yaml.safe_load(stream)
+        self.fixtures = self.all_fixtures.get(
+                self.fixture_name(),
+                {'should_match': [], 'should_not_match': []}
+        )
+        self.classifier = self.classifier_instance()
+        self.tokenizer = Tokenize('varlexapp/data/gene_symbols.txt')
+
+    def classifier_instance(self):
+        raise NotImplementedError()
+
+    def fixture_name(self):
+        raise NotImplementedError()
+
+    def test_matches(self):
+        for x in self.fixtures['should_match']:
+            tokens = self.tokenizer.perform(x['query'])
+            classification = self.classifier.match(tokens)
+            self.assertIsNotNone(classification)
+            self.assertEqual(str(classification.confidence), x['confidence'])
+
+    def test_not_matches(self):
+        for x in self.fixtures['should_not_match']:
+            tokens = self.tokenizer.perform(x['query'])
+            classification = self.classifier.match(tokens)
+            self.assertIsNone(classification)

--- a/tests/classifiers/test_fusion.py
+++ b/tests/classifiers/test_fusion.py
@@ -1,0 +1,12 @@
+import unittest
+
+from varlexapp.classifiers import FusionClassifier
+from .classifier_base import ClassifierBase
+
+class TestGenePairTokenizer(ClassifierBase, unittest.TestCase):
+
+    def classifier_instance(self):
+        return FusionClassifier()
+
+    def fixture_name(self):
+        return 'fusion'

--- a/tests/fixtures/classifiers.yml
+++ b/tests/fixtures/classifiers.yml
@@ -1,0 +1,19 @@
+fusion:
+  should_match:
+    - query: braf-flt3 fusion
+      confidence: EXACT
+    - query: braf-flt3
+      confidence: EXACT
+    - query: braf fusion
+      confidence: EXACT
+    - query: fusion braf
+      confidence: UNORDERED
+    - query: flt3-braf fusion foo
+      confidence: SUPERSET
+    - query: flt3 foo
+      confidence: INTERSECTION
+  should_not_match:
+    - query: afusion
+    - query: fused
+    - query: fusio
+

--- a/tests/fixtures/tokenizers.yml
+++ b/tests/fixtures/tokenizers.yml
@@ -9,4 +9,24 @@ fusion:
     - token: fused
     - token: fusio
 
+gene_pair:
+  should_match:
+    - token: flt3-braf
+    - token: braf-abl1
+    - token: HGNC:1097-abl1
+    - token: ncbigene:673-flt3
+  should_not_match:
+    - token: foo-braf
+    - token: ncbigene:-673-flt3
+
+gene:
+  should_match:
+    - token: flt3
+    - token: abl
+    - token: abl1
+    - token: HGNC:1097
+    - token: ncbigene:673
+    - token: ensembl:ENSG00000157764
+  should_not_match:
+    - token: not-a-gene
 

--- a/tests/tokenizers/test_gene.py
+++ b/tests/tokenizers/test_gene.py
@@ -1,0 +1,18 @@
+import unittest
+
+from varlexapp.tokenizers import GeneSymbol
+from varlexapp.tokenizers.caches import GeneSymbolCache
+from .tokenizer_base import TokenizerBase
+
+class TestGenePairTokenizer(TokenizerBase, unittest.TestCase):
+
+    #todo: don't hardcode this, inject with config
+    def tokenizer_instance(self):
+        gene_cache = GeneSymbolCache('varlexapp/data/gene_symbols.txt')
+        return GeneSymbol(gene_cache)
+
+    def token_type(self):
+        return 'GeneSymbol'
+
+    def fixture_name(self):
+        return 'gene'

--- a/tests/tokenizers/test_gene_pair.py
+++ b/tests/tokenizers/test_gene_pair.py
@@ -1,0 +1,18 @@
+import unittest
+
+from varlexapp.tokenizers import GenePair
+from varlexapp.tokenizers.caches import GeneSymbolCache
+from .tokenizer_base import TokenizerBase
+
+class TestGenePairTokenizer(TokenizerBase, unittest.TestCase):
+
+    #todo: don't hardcode this, inject with config
+    def tokenizer_instance(self):
+        gene_cache = GeneSymbolCache('varlexapp/data/gene_symbols.txt')
+        return GenePair(gene_cache)
+
+    def token_type(self):
+        return 'GenePair'
+
+    def fixture_name(self):
+        return 'gene_pair'

--- a/varlexapp/models/classification_type.py
+++ b/varlexapp/models/classification_type.py
@@ -15,4 +15,4 @@ class ClassificationType(Enum):
     COMPLEX = 10
 
     def __str__(self):
-        self.name
+        return self.name

--- a/varlexapp/models/confidence_rating.py
+++ b/varlexapp/models/confidence_rating.py
@@ -8,4 +8,4 @@ class ConfidenceRating(Enum):
     EXACT = 4
 
     def __str__(self):
-        self.name
+        return self.name


### PR DESCRIPTION
This allows us to test both that the string is classified correctly and with the confidence level we expect.

Right now it loads the gene cache per set of tests which makes it slower than it should be. We should optimize that out in a future PR.